### PR TITLE
Follow-up: Helpers for EPRE custom checks

### DIFF
--- a/data_checks/checks/base.py
+++ b/data_checks/checks/base.py
@@ -1,0 +1,217 @@
+"""
+Helpers for declarative data checks.
+
+These base classes implement common code for checking cell, row, and column constraints.
+"""
+import abc
+from typing import Any, Collection, Dict, List, Optional, Sequence, Set
+
+from goodtables import Error
+
+
+class BaseCheck:
+    """
+    Base check, with error construction.
+    """
+
+    options: Dict[str, Any]
+
+    error_code: str
+    error_message: str
+
+    def __init__(self, **options: Any) -> None:
+        self.options = options
+
+    def check_row(self, cells: Sequence[dict]) -> Optional[List[Error]]:
+        """
+        See `goodtables.inspector.Inspector`
+        """
+
+    def check_table(self) -> Optional[List[Error]]:
+        """
+        See `goodtables.inspector.Inspector`
+        """
+
+    def get_error(
+        self,
+        cell: Optional[dict] = None,
+        row_number: Optional[int] = None,
+        message_substitutions: Optional[dict] = None,
+    ) -> Error:
+        """
+        Construct an `Error` for this check.
+        """
+        message = self.error_message
+        error = Error(
+            code=self.error_code,
+            cell=cell,
+            row_number=row_number,
+            message=message,
+            message_substitutions=message_substitutions,
+        )
+
+        # Check message validity:
+        try:
+            error.message
+        except KeyError as e:
+            raise ValueError(
+                f"Missing error message substitution: {e} in {message!r}"
+            ) from e
+
+        return error
+
+
+def _get_row_number(cells: Sequence[dict]) -> Optional[int]:
+    # XXX: No handling of more than one row-number value, for now.
+    for cell in cells:
+        if cell.get("row-number"):
+            return cell.get("row-number")
+    else:
+        return None
+
+
+def _get_row_data(cells: Sequence[dict]) -> dict:
+    row_data = {cell["header"]: cell["value"] for cell in cells}
+    # Consistency check: bail out on conflicting cell headers, for now.
+    assert len(row_data.keys()) == len(cells), cells
+    return row_data
+
+
+class BaseRowCheck(BaseCheck, abc.ABC):
+    """
+    Base check for row constraints.
+
+    Subclasses must provide `check_row_data`.
+    """
+
+    def check_row(self, cells: Sequence[dict]) -> Optional[List[Error]]:
+        row_data = _get_row_data(cells)
+        if self.should_check_row(row_data) and not self.check_row_data(row_data):
+            row_number = _get_row_number(cells)
+            return [
+                self.get_error(
+                    row_number=row_number,
+                    message_substitutions=self.get_row_error_message_substitutions(
+                        row_data
+                    ),
+                )
+            ]
+        else:
+            return None
+
+    def should_check_row(self, row_data: dict) -> bool:
+        """
+        Override this to check only a subset of rows.
+        """
+        return True
+
+    @abc.abstractmethod
+    def check_row_data(self, row_data: dict) -> bool:
+        """
+        Return True if the row data is valid.
+        """
+
+    def get_row_error_message_substitutions(self, row_data: dict) -> dict:
+        """
+        Error context for the row.
+
+        Extend this to provide additional context.
+        """
+        return {}
+
+
+class BaseCellCheck(BaseCheck, abc.ABC):
+    """
+    Base check for cell value constraints.
+
+    Subclasses must provide `check_cell_value`.
+    """
+
+    def check_row(self, cells: Sequence[dict]) -> Optional[List[Error]]:
+        return [
+            self.get_error(
+                cell=cell,
+                message_substitutions=self.get_cell_error_message_substitutions(cell),
+            )
+            for cell in cells
+            if self.should_check_cell(cell)
+            if not self.check_cell_value(cell["value"])
+        ]
+
+    def should_check_cell(self, cell: dict) -> bool:
+        """
+        Override this to check only a subset of cells.
+        """
+        return True
+
+    @abc.abstractmethod
+    def check_cell_value(self, value: str) -> bool:
+        """
+        Return True if the cell value is valid.
+        """
+
+    def get_cell_error_message_substitutions(self, cell: dict) -> dict:
+        """
+        Error context for the cell: `header` and `value`
+
+        Extend this to provide context.
+        """
+        return {"header": cell["header"], "value": cell["value"]}
+
+
+class BaseColumnValueCheck(BaseCellCheck):
+    """
+    Base check for named columns constraints.
+
+    Subclasses must provide `column_header` and `check_cell_value`.
+    """
+
+    column_header: str
+
+    def __init__(self, column_header: Optional[str] = None, **options: Any):
+        super().__init__()
+        if column_header is not None:
+            self.column_header = column_header
+        assert hasattr(self, "column_header"), f"missing column_header for {self}"
+
+    def should_check_cell(self, cell: dict) -> bool:
+        return self.column_header == cell["header"]
+
+
+class BaseRequiredColumnValueCheck(BaseColumnValueCheck):
+    """
+    Base check: Column contains one or more required values.
+
+    Subclasses must provide `column_header` and `required_values`.
+    """
+
+    error_message = (
+        'Table does not contain the "{missing_value}" value'
+        " in the {header} column at least once"
+    )
+
+    required_values: Collection[str]
+    seen_values: Set[str]
+
+    def __init__(self, **options: Any):
+        super().__init__(**options)
+        self.seen_values = set()
+
+    def check_cell_value(self, value: str) -> bool:
+        self.seen_values.add(value)
+        return True
+
+    def check_table(self) -> Optional[List[Error]]:
+        # Iterate instead of using set arithmetic, to retain consistent reporting order.
+        missing_values = [
+            value for value in self.required_values if value not in self.seen_values
+        ]
+        return [
+            self.get_error(
+                message_substitutions={
+                    "header": self.column_header,
+                    "missing_value": missing_value,
+                }
+            )
+            for missing_value in missing_values
+        ]

--- a/data_checks/checks/epre/budget_phase_for_new_financial_year.py
+++ b/data_checks/checks/epre/budget_phase_for_new_financial_year.py
@@ -1,8 +1,10 @@
-from goodtables import validate, check, Error, registry
+from goodtables import check
+
+from data_checks.checks.base import BaseRowCheck
 
 
-@check('budget-phase-for-new-financial-year', type='custom', context='body')
-class BudgetPhaseForNewFinancialYear(object):
+@check("budget-phase-for-new-financial-year", type="custom", context="body")
+class BudgetPhaseForNewFinancialYear(BaseRowCheck):
     """
     Budget Phase column for rows where Financial Year is the dataset's
     new financial year must be "Main appropriation" - that is - if the
@@ -10,72 +12,37 @@ class BudgetPhaseForNewFinancialYear(object):
     Phase must be Main Appropriation.
     """
 
+    error_code = "budget-phase-for-new-financial-year"
+    error_message = (
+        "{actual_budget_phase} in column {budget_phase_column}"
+        ' must be "{expected_budget_phase}"'
+        ' when column {financial_year_column} is "{new_year}"'
+        " on row {row_number}"
+    )
+
     def __init__(self, new_year, expected_budget_phase="Main appropriation",
-                 budget_phase_column="BudgetPhase",
-                 financial_year_column="FinancialYear", **options):
+        budget_phase_column="BudgetPhase",
+        financial_year_column="FinancialYear", **options):
+        super().__init__(**options)
         self.new_year = new_year
         self.expected_budget_phase = expected_budget_phase
-        self.__budget_phase_column = budget_phase_column
-        self.__financial_year_column = financial_year_column
+        self.budget_phase_column = budget_phase_column
+        self.financial_year_column = financial_year_column
 
-    def check_row(self, cells):
-        """
-        Get the row's budget_phase values and remove them from the
-        required values that still need to be found.
-        """
+    def should_check_row(self, row_data: dict) -> bool:
+        return self.new_year == row_data[self.financial_year_column]
 
-        def is_new_financial_year_value(cell):
-            return (cell.get("header") == self.__financial_year_column and
-                    cell.get("value") == self.new_year)
+    def check_row_data(self, row_data: dict) -> bool:
+        return self.expected_budget_phase == row_data.get(self.budget_phase_column)
 
-        def is_budget_phase_value(cell):
-            return cell.get("header") == self.__budget_phase_column
-
-        def is_expected_budget_phase_value(cell):
-            return (is_budget_phase_value(cell) and
-            cell.get("value") == self.expected_budget_phase)
-
-        errors = []
-
-        new_year_values = list(filter(is_new_financial_year_value, cells))
-
-        budget_phase_values = list(filter(is_budget_phase_value, cells))
-
-        expected_budget_phase_values = list(
-            filter(is_expected_budget_phase_value, budget_phase_values))
-
-        # If at least one of the financial_year values are the new year
-        # then there must be one budget_phase value which is the expected
-        # budget phase
-        if new_year_values and not expected_budget_phase_values:
-            if budget_phase_values:
-                message = (
-                    f'Value "{budget_phase_values[0].get("value")}" '
-                    f'in column {self.__budget_phase_column} must be '
-                    f'"{self.expected_budget_phase}" when '
-                    f'column {self.__financial_year_column} '
-                    f'is "{self.new_year}" on row '
-                    f'{new_year_values[0].get("row-number")}'
-                )
-            else:
-                message = (
-                    f'Empty value '
-                    f'in column {self.__budget_phase_column} must be '
-                    f'"{self.expected_budget_phase}" when '
-                    f'column {self.__financial_year_column} '
-                    f'is "{self.new_year}" on row '
-                    f'{new_year_values[0].get("row-number")}'
-                )
-
-            error = Error(
-                'budget-phase-for-new-financial-year',
-                message=message,
-                cell=new_year_values[0],
-                row_number=new_year_values[0].get("row-number"),
-            )
-            errors.append(error)
-
-        return errors
-
-    def check_table(self):
-        pass
+    def get_row_error_message_substitutions(self, row_data: dict) -> dict:
+        budget_phase = row_data.get("budget_phase")
+        actual_budget_phase = f'"{budget_phase}"' if budget_phase else "Empty value"
+        return {
+            **super().get_row_error_message_substitutions(row_data),
+            "actual_budget_phase": actual_budget_phase,
+            "expected_budget_phase": self.expected_budget_phase,
+            "new_year": self.new_year,
+            "budget_phase_column": self.budget_phase_column,
+            "financial_year_column": self.financial_year_column,
+        }

--- a/data_checks/checks/epre/budget_phase_required_values.py
+++ b/data_checks/checks/epre/budget_phase_required_values.py
@@ -48,7 +48,7 @@ class BudgetPhaseRequiredValues(object):
         """
         errors = []
 
-        for required_value in self.__required_values_left:
+        for required_value in sorted(self.__required_values_left):
             error = Error('budget-phase-required-values',
                           message=('Table does not contain the '
                                    f' "{required_value}" value in the '

--- a/data_checks/checks/epre/budget_phase_required_values.py
+++ b/data_checks/checks/epre/budget_phase_required_values.py
@@ -1,8 +1,10 @@
-from goodtables import validate, check, Error, registry
+from goodtables import check
+
+from data_checks.checks.base import BaseRequiredColumnValueCheck
 
 
-@check('budget-phase-required-values', type='custom', context='body')
-class BudgetPhaseRequiredValues(object):
+@check("budget-phase-required-values", type="custom", context="body")
+class BudgetPhaseRequiredValues(BaseRequiredColumnValueCheck):
     """
     Check that there is at least one row where Budget Phase has
     each of the following values:
@@ -12,47 +14,13 @@ class BudgetPhaseRequiredValues(object):
         - 'Medium Term Estimates'.
     """
 
+    error_code = "budget-phase-required-values"
+
+    column_header = "BudgetPhase"
+
     required_values = [
-        'Audited Outcome',
-        'Adjusted appropriation',
-        'Main appropriation',
-        'Medium Term Estimates',
+        "Audited Outcome",
+        "Adjusted appropriation",
+        "Main appropriation",
+        "Medium Term Estimates",
     ]
-
-    def __init__(self, budget_phase_column='BudgetPhase', **options):
-        self.__required_values_left = set(self.required_values)
-        self.__budget_phase_column = budget_phase_column
-
-    def check_row(self, cells):
-        """
-        Get the row's budget_phase values and remove them from the required
-        values that still need to be found.
-        """
-        errors = []
-
-        budget_phase_values = list(filter(
-            lambda cell: cell.get('header') == self.__budget_phase_column, cells))
-
-        # Eliminate budget_values that were found
-        for budget_phase_value in budget_phase_values:
-            self.__required_values_left.discard(
-                budget_phase_value.get('value'))
-
-        return errors
-
-    def check_table(self):
-        """
-        After all the rows have been checked, check if there are any required
-        values left to be found and return an error for each of the values
-        still to be found.
-        """
-        errors = []
-
-        for required_value in sorted(self.__required_values_left):
-            error = Error('budget-phase-required-values',
-                          message=('Table does not contain the '
-                                   f' "{required_value}" value in the '
-                                   f'{self.__budget_phase_column} column at least once'))
-            errors.append(error)
-
-        return errors

--- a/data_checks/checks/epre/department_names_required_characters.py
+++ b/data_checks/checks/epre/department_names_required_characters.py
@@ -1,47 +1,31 @@
-import string
+from goodtables import check
 
-from goodtables import validate, check, Error, registry
+from data_checks.checks.base import BaseColumnValueCheck
 
 
-@check('department-names-required-characters', type='custom', context='body')
-class DepartmentNamesRequiredCharacters(object):
+def has_lower(s: str) -> bool:
+    return any(c.islower() for c in s)
+
+
+def has_upper(s: str) -> bool:
+    return any(c.isupper() for c in s)
+
+
+@check("department-names-required-characters", type="custom", context="body")
+class DepartmentNamesRequiredCharacters(BaseColumnValueCheck):
     """
     Department names must contain [A-Z] and [a-z]
     (capitalised and non-capitalised).
     """
 
-    def __init__(self, department_column="Department", **options):
-        self.__department_column = department_column
+    error_code = "department-names-required-characters"
+    error_message = (
+        'Value "{value}" in column {header}'
+        " must contain [A-Z] and [a-z] (capitalised and non-capitalised) characters"
+        " on row {row_number}"
+    )
 
-    def check_row(self, cells):
-        """
-        Get the row's department names and check that they contain
-        [A-Z] and [a-z] characters.
-        """
+    column_header = "department"
 
-        def is_department_without_a_z_and_A_Z(cell):
-            """
-            Check if a cell has the department header and doesn't contain
-            both lowercase and uppercase letters.
-            """
-            return cell.get("header") == self.__department_column and not (
-                any(c in cell.get("value") for c in string.ascii_lowercase) and
-                any(c in cell.get("value") for c in string.ascii_uppercase)
-            )
-
-        # Filter the department names for those without both lowercase and
-        # uppercase letters.
-        departments = list(filter(is_department_without_a_z_and_A_Z, cells))
-
-        errors = [Error(code='department-names-required-characters',
-                        message=(f'Value "{cell.get("value")}" in column '
-                                 f'{self.__department_column} must contain [A-Z] and [a-z] '
-                                 '(capitalised and non-capitalised) characters '
-                                 f'on row {cell.get("row-number")}'),
-                        cell=cell,
-                        ) for cell in departments]
-
-        return errors
-
-    def check_table(self):
-        pass
+    def check_cell_value(self, value: str) -> bool:
+        return has_lower(value) and has_upper(value)

--- a/tests/checks/epre/test_budget_phase_for_new_financial_year.py
+++ b/tests/checks/epre/test_budget_phase_for_new_financial_year.py
@@ -1,96 +1,102 @@
 import unittest
 
-from goodtables import cells, checks, validate, Error
 import goodtables.cells
 
-from data_checks.checks.epre.budget_phase_for_new_financial_year \
-    import BudgetPhaseForNewFinancialYear
+from data_checks.checks.epre.budget_phase_for_new_financial_year import (
+    BudgetPhaseForNewFinancialYear,
+)
+
+from ..helpers import BaseCheckTestCase
 
 
-class TestBudgetPhaseForNewFinancialYear(unittest.TestCase):
-    def test_correct_expected_budget_phase(self):
-        new_year = 2018
-        expected_budget_phase = "Main Appropriation"
-        check = BudgetPhaseForNewFinancialYear(
-            new_year, expected_budget_phase,
+class TestBudgetPhaseForNewFinancialYear(BaseCheckTestCase):
+    new_year = 2018
+    expected_budget_phase = "Main Appropriation"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.check = BudgetPhaseForNewFinancialYear(
+            self.new_year,
+            self.expected_budget_phase,
             budget_phase_column="budget_phase",
-            financial_year_column="financial_year")
+            financial_year_column="financial_year",
+        )
+
+    def test_correct_expected_budget_phase(self):
         cells = [
             goodtables.cells.create_cell(
-                'budget_phase', expected_budget_phase,
-                'budget_phase', row_number=1),
+                "budget_phase", self.expected_budget_phase, "budget_phase", row_number=1
+            ),
             goodtables.cells.create_cell(
-                'financial_year', new_year, 'financial_year', row_number=1),
+                "financial_year", self.new_year, "financial_year", row_number=1
+            ),
         ]
-
-        errors = check.check_row(cells)
-
-        self.assertEqual(len(errors), 0,
-                         ('No errors should be returned when '
-                          'the expected budget phase was given'))
+        errors = self.run_checks(self.check, [cells])
+        self.assertCheckErrors([], errors)
 
     def test_incorrect_expected_budget_phase(self):
-        new_year = 2018
-        expected_budget_phase = "Main Appropriation"
-        check = BudgetPhaseForNewFinancialYear(
-            new_year, expected_budget_phase,
-            budget_phase_column="budget_phase",
-            financial_year_column="financial_year")
         cells = [
             goodtables.cells.create_cell(
-                'budget_phase', 'Not an expected budget phase',
-                'budget_phase', row_number=1),
+                "budget_phase",
+                "Not an expected budget phase",
+                "budget_phase",
+                row_number=1,
+            ),
             goodtables.cells.create_cell(
-                'financial_year', new_year, 'financial_year', row_number=1),
+                "financial_year", self.new_year, "financial_year", row_number=1
+            ),
         ]
+        errors = self.run_checks(self.check, [cells])
 
-        errors = check.check_row(cells)
-
-        self.assertEqual(len(errors), 1,
-                         ('An error should be returned when '
-                          'an unexpected budget phase was given'))
-        self.assertEqual(errors[0].code, 'budget-phase-for-new-financial-year')
-        self.assertEqual(errors[0].row_number, 1)
-        self.assertIsNotNone(errors[0].message)
+        expected_errors = [
+            {
+                "code": "budget-phase-for-new-financial-year",
+                "row-number": 1,
+                "column-number": None,
+                "message": (
+                    'Value "Not an expected budget phase" in column budget_phase must '
+                    'be "Main Appropriation" when column financial_year is "2018" on row 1'
+                ),
+                "message-data": {},
+            }
+        ]
+        self.assertCheckErrors(expected_errors, errors)
 
     def test_no_expected_budget_phase(self):
-        new_year = 2018
-        expected_budget_phase = "Main Appropriation"
-        check = BudgetPhaseForNewFinancialYear(
-            new_year, expected_budget_phase,
-            budget_phase_column="budget_phase",
-            financial_year_column="financial_year")
         cells = [
             goodtables.cells.create_cell(
-                'financial_year', new_year, 'financial_year', row_number=1),
+                "financial_year", self.new_year, "financial_year", row_number=1
+            )
         ]
+        errors = self.run_checks(self.check, [cells])
 
-        errors = check.check_row(cells)
-
-        self.assertEqual(len(errors), 1, ('An error should be returned when '
-                                          'no budget phase was given'))
+        expected_errors = [
+            {
+                "code": "budget-phase-for-new-financial-year",
+                "row-number": 1,
+                "column-number": None,
+                "message": 'Empty value in column budget_phase must be "Main Appropriation" '
+                'when column financial_year is "2018" on row 1',
+                "message-data": {},
+            }
+        ]
+        self.assertCheckErrors(expected_errors, errors)
 
     def test_unexpected_budget_phase_for_different_year(self):
-        new_year = 2018
-        expected_budget_phase = "Main Appropriation"
-        check = BudgetPhaseForNewFinancialYear(
-            new_year, expected_budget_phase,
-            budget_phase_column="budget_phase",
-            financial_year_column="financial_year")
         cells = [
             goodtables.cells.create_cell(
-                'budget_phase', 'Not an expected budget phase',
-                'budget_phase', row_number=1),
+                "budget_phase",
+                "Not an expected budget phase",
+                "budget_phase",
+                row_number=1,
+            ),
             goodtables.cells.create_cell(
-                'financial_year', new_year + 1, 'financial_year', row_number=1),
+                "financial_year", self.new_year + 1, "financial_year", row_number=1
+            ),
         ]
-
-        errors = check.check_row(cells)
-
-        self.assertEqual(len(errors), 0, ('No errors should be returned when '
-                                          'the financial year wasn\'t the new '
-                                          'year'))
+        errors = self.run_checks(self.check, [cells])
+        self.assertCheckErrors([], errors)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/checks/epre/test_budget_phase_for_new_financial_year.py
+++ b/tests/checks/epre/test_budget_phase_for_new_financial_year.py
@@ -54,10 +54,16 @@ class TestBudgetPhaseForNewFinancialYear(BaseCheckTestCase):
                 "row-number": 1,
                 "column-number": None,
                 "message": (
-                    'Value "Not an expected budget phase" in column budget_phase must '
+                    '"Not an expected budget phase" in column budget_phase must '
                     'be "Main Appropriation" when column financial_year is "2018" on row 1'
                 ),
-                "message-data": {},
+                "message-data": {
+                    "actual_budget_phase": "Not an expected budget phase",
+                    "budget_phase_column": "budget_phase",
+                    "expected_budget_phase": "Main Appropriation",
+                    "financial_year_column": "financial_year",
+                    "new_year": 2018,
+                },
             }
         ]
         self.assertCheckErrors(expected_errors, errors)
@@ -77,7 +83,13 @@ class TestBudgetPhaseForNewFinancialYear(BaseCheckTestCase):
                 "column-number": None,
                 "message": 'Empty value in column budget_phase must be "Main Appropriation" '
                 'when column financial_year is "2018" on row 1',
-                "message-data": {},
+                "message-data": {
+                    "actual_budget_phase": "Empty value",
+                    "budget_phase_column": "budget_phase",
+                    "expected_budget_phase": "Main Appropriation",
+                    "financial_year_column": "financial_year",
+                    "new_year": 2018,
+                },
             }
         ]
         self.assertCheckErrors(expected_errors, errors)

--- a/tests/checks/epre/test_budget_phase_required_values.py
+++ b/tests/checks/epre/test_budget_phase_required_values.py
@@ -1,84 +1,90 @@
 import unittest
 
-from goodtables import cells, checks, validate, Error
 import goodtables.cells
 
-from data_checks.checks.epre.budget_phase_required_values \
-    import BudgetPhaseRequiredValues
+from data_checks.checks.epre.budget_phase_required_values import (
+    BudgetPhaseRequiredValues,
+)
+
+from ..helpers import BaseCheckTestCase
 
 
-class TestBudgetPhaseRequiredValues(unittest.TestCase):
+class TestBudgetPhaseRequiredValues(BaseCheckTestCase):
     def setUp(self):
+        super().setUp()
         self.required_values = [
-            'Audited Outcome',
-            'Adjusted appropriation',
-            'Main appropriation',
-            'Medium Term Estimates',
+            "Audited Outcome",
+            "Adjusted appropriation",
+            "Main appropriation",
+            "Medium Term Estimates",
         ]
-        self.check = BudgetPhaseRequiredValues(
-            budget_phase_column="budget_phase")
+        self.check = BudgetPhaseRequiredValues(budget_phase_column="budget_phase")
 
     def test_contains_one_of_each_required_value(self):
         cells = [
-            goodtables.cells.create_cell('budget_phase', value, 'budget_phase')
+            goodtables.cells.create_cell("budget_phase", value, "budget_phase")
             for value in self.required_values
         ]
+        errors = self.run_checks(self.check, [cells])
 
-        errors = self.check.check_row(cells)
-        errors += self.check.check_table()
-
-        self.assertEqual(
-            len(errors), 0,
-            ('No errors should be returned for cells '
-             'that contain each of the required budget_phase values'))
+        self.assertCheckErrors([], errors)
 
     def test_contains_duplicates_of_each_required_value(self):
         cells = [
-            goodtables.cells.create_cell('budget_phase', value, 'budget_phase')
+            goodtables.cells.create_cell("budget_phase", value, "budget_phase")
             for value in self.required_values * 2
         ]
+        errors = self.run_checks(self.check, [cells])
 
-        errors = self.check.check_row(cells)
-        errors += self.check.check_table()
-
-        self.assertEqual(
-            len(errors), 0,
-            ('No errors should be returned '
-             'for cells that contain each of the required '
-             'budget_phase values'))
+        self.assertCheckErrors([], errors)
 
     def test_contains_some_required_values(self):
         required_values_present = 2
 
         cells = [
-            goodtables.cells.create_cell('budget_phase', value, 'budget_phase')
+            goodtables.cells.create_cell("budget_phase", value, "budget_phase")
             for value in self.required_values[0:required_values_present]
         ]
+        errors = self.run_checks(self.check, [cells])
 
-        errors = self.check.check_row(cells)
-        errors += self.check.check_table()
-
-        self.assertEqual(len(errors),
-                         len(self.required_values) - required_values_present,
-                         ('No errors should be returned for cells that '
-                          'contain each of the required budget_phase values'))
-        self.assertEqual(errors[0].code, 'budget-phase-required-values')
-        self.assertIsNotNone(errors[0].message)
+        expected_errors = [
+            {
+                "code": "budget-phase-required-values",
+                "row-number": None,
+                "column-number": None,
+                "message": (
+                    f'Table does not contain the  "{value}" value'
+                    " in the budget_phase column at least once"
+                ),
+                "message-data": {},
+            }
+            for value in sorted(self.required_values[required_values_present:])
+        ]
+        self.assertCheckErrors(expected_errors, errors)
 
     def test_contains_no_required_values(self):
         cells = [
             goodtables.cells.create_cell(
-                'budget_phase', 'not a required value', 'budget_phase')
+                "budget_phase", "not a required value", "budget_phase"
+            )
         ]
+        errors = self.run_checks(self.check, [cells])
 
-        errors = self.check.check_row(cells)
-        errors += self.check.check_table()
+        expected_errors = [
+            {
+                "code": "budget-phase-required-values",
+                "row-number": None,
+                "column-number": None,
+                "message": (
+                    f'Table does not contain the  "{value}" value'
+                    " in the budget_phase column at least once"
+                ),
+                "message-data": {},
+            }
+            for value in sorted(self.required_values)
+        ]
+        self.assertCheckErrors(expected_errors, errors)
 
-        self.assertEqual(len(errors), len(self.required_values),
-                         ('One error for each of the required '
-                          'values should be returned if the dataset '
-                          'contains none of the required values.'))
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/checks/epre/test_budget_phase_required_values.py
+++ b/tests/checks/epre/test_budget_phase_required_values.py
@@ -18,7 +18,7 @@ class TestBudgetPhaseRequiredValues(BaseCheckTestCase):
             "Main appropriation",
             "Medium Term Estimates",
         ]
-        self.check = BudgetPhaseRequiredValues(budget_phase_column="budget_phase")
+        self.check = BudgetPhaseRequiredValues(column_header="budget_phase")
 
     def test_contains_one_of_each_required_value(self):
         cells = [
@@ -53,12 +53,12 @@ class TestBudgetPhaseRequiredValues(BaseCheckTestCase):
                 "row-number": None,
                 "column-number": None,
                 "message": (
-                    f'Table does not contain the  "{value}" value'
+                    f'Table does not contain the "{value}" value'
                     " in the budget_phase column at least once"
                 ),
-                "message-data": {},
+                "message-data": {"header": "budget_phase", "missing_value": value},
             }
-            for value in sorted(self.required_values[required_values_present:])
+            for value in self.required_values[required_values_present:]
         ]
         self.assertCheckErrors(expected_errors, errors)
 
@@ -76,12 +76,12 @@ class TestBudgetPhaseRequiredValues(BaseCheckTestCase):
                 "row-number": None,
                 "column-number": None,
                 "message": (
-                    f'Table does not contain the  "{value}" value'
+                    f'Table does not contain the "{value}" value'
                     " in the budget_phase column at least once"
                 ),
-                "message-data": {},
+                "message-data": {"header": "budget_phase", "missing_value": value},
             }
-            for value in sorted(self.required_values)
+            for value in self.required_values
         ]
         self.assertCheckErrors(expected_errors, errors)
 

--- a/tests/checks/epre/test_department_names_required_characters.py
+++ b/tests/checks/epre/test_department_names_required_characters.py
@@ -12,7 +12,7 @@ from ..helpers import BaseCheckTestCase
 class TestDepartmentNamesRequiredCharacters(BaseCheckTestCase):
     def setUp(self):
         super().setUp()
-        self.check = DepartmentNamesRequiredCharacters(department_column="department")
+        self.check = DepartmentNamesRequiredCharacters(column_header="department")
 
     def test_contains_only_lowercase_characters(self):
         cells = [
@@ -32,7 +32,7 @@ class TestDepartmentNamesRequiredCharacters(BaseCheckTestCase):
                 "column-number": None,
                 "message": 'Value "only lowercase" in column department must contain [A-Z] '
                 "and [a-z] (capitalised and non-capitalised) characters on row 1",
-                "message-data": {},
+                "message-data": {"header": "department", "value": "only lowercase"},
             },
             {
                 "code": "department-names-required-characters",
@@ -40,7 +40,7 @@ class TestDepartmentNamesRequiredCharacters(BaseCheckTestCase):
                 "column-number": None,
                 "message": 'Value "only lowercase" in column department must contain [A-Z] '
                 "and [a-z] (capitalised and non-capitalised) characters on row 2",
-                "message-data": {},
+                "message-data": {"header": "department", "value": "only lowercase"},
             },
         ]
         self.assertCheckErrors(expected_errors, errors)
@@ -61,7 +61,7 @@ class TestDepartmentNamesRequiredCharacters(BaseCheckTestCase):
                 "column-number": None,
                 "message": 'Value "ONLY UPPERCASE" in column department must contain [A-Z] '
                 "and [a-z] (capitalised and non-capitalised) characters on row 4",
-                "message-data": {},
+                "message-data": {"header": "department", "value": "ONLY UPPERCASE"},
             }
         ]
         self.assertCheckErrors(expected_errors, errors)
@@ -81,7 +81,7 @@ class TestDepartmentNamesRequiredCharacters(BaseCheckTestCase):
                 "column-number": None,
                 "message": 'Value "12345!@)#(*" in column department must contain [A-Z] and '
                 "[a-z] (capitalised and non-capitalised) characters on row 4",
-                "message-data": {},
+                "message-data": {"header": "department", "value": "12345!@)#(*"},
             }
         ]
         self.assertCheckErrors(expected_errors, errors)

--- a/tests/checks/epre/test_department_names_required_characters.py
+++ b/tests/checks/epre/test_department_names_required_characters.py
@@ -1,73 +1,106 @@
 import unittest
 
-from goodtables import cells, checks, validate, Error
 import goodtables.cells
 
-from data_checks.checks.epre.department_names_required_characters import \
-    DepartmentNamesRequiredCharacters
+from data_checks.checks.epre.department_names_required_characters import (
+    DepartmentNamesRequiredCharacters,
+)
+
+from ..helpers import BaseCheckTestCase
 
 
-class TestDepartmentNamesRequiredCharacters(unittest.TestCase):
+class TestDepartmentNamesRequiredCharacters(BaseCheckTestCase):
     def setUp(self):
-        self.check = DepartmentNamesRequiredCharacters(
-            department_column="department")
+        super().setUp()
+        self.check = DepartmentNamesRequiredCharacters(department_column="department")
 
     def test_contains_only_lowercase_characters(self):
         cells = [
             goodtables.cells.create_cell(
-                'department', 'only lowercase', 'department', row_number=1),
+                "department", "only lowercase", "department", row_number=1
+            ),
             goodtables.cells.create_cell(
-                'department', 'only lowercase', 'department', row_number=2)
+                "department", "only lowercase", "department", row_number=2
+            ),
         ]
+        errors = self.run_checks(self.check, [cells])
 
-        errors = self.check.check_row(cells)
-
-        self.assertEqual(len(errors), 2)
-        self.assertEqual(errors[0].row_number, 1)
-        self.assertEqual(
-            errors[0].code, 'department-names-required-characters')
+        expected_errors = [
+            {
+                "code": "department-names-required-characters",
+                "row-number": 1,
+                "column-number": None,
+                "message": 'Value "only lowercase" in column department must contain [A-Z] '
+                "and [a-z] (capitalised and non-capitalised) characters on row 1",
+                "message-data": {},
+            },
+            {
+                "code": "department-names-required-characters",
+                "row-number": 2,
+                "column-number": None,
+                "message": 'Value "only lowercase" in column department must contain [A-Z] '
+                "and [a-z] (capitalised and non-capitalised) characters on row 2",
+                "message-data": {},
+            },
+        ]
+        self.assertCheckErrors(expected_errors, errors)
 
     def test_contains_only_uppercase_characters(self):
         cells = [
             goodtables.cells.create_cell(
-                'department', 'ONLY UPPERCASE', 'department', row_number=4)
+                "department", "ONLY UPPERCASE", "department", row_number=4
+            )
         ]
 
-        errors = self.check.check_row(cells)
+        errors = self.run_checks(self.check, [cells])
 
-        self.assertEqual(len(errors), 1)
-        self.assertEqual(errors[0].row_number, 4)
-        self.assertEqual(
-            errors[0].code, 'department-names-required-characters')
+        expected_errors = [
+            {
+                "code": "department-names-required-characters",
+                "row-number": 4,
+                "column-number": None,
+                "message": 'Value "ONLY UPPERCASE" in column department must contain [A-Z] '
+                "and [a-z] (capitalised and non-capitalised) characters on row 4",
+                "message-data": {},
+            }
+        ]
+        self.assertCheckErrors(expected_errors, errors)
 
     def test_contains_only_non_alphabetical_characters(self):
         cells = [
             goodtables.cells.create_cell(
-                'department', '12345!@)#(*', 'department', row_number=4),
+                "department", "12345!@)#(*", "department", row_number=4
+            )
         ]
+        errors = self.run_checks(self.check, [cells])
 
-        errors = self.check.check_row(cells)
-
-        self.assertEqual(len(errors), 1)
-        self.assertEqual(
-            errors[0].code, 'department-names-required-characters')
+        expected_errors = [
+            {
+                "code": "department-names-required-characters",
+                "row-number": 4,
+                "column-number": None,
+                "message": 'Value "12345!@)#(*" in column department must contain [A-Z] and '
+                "[a-z] (capitalised and non-capitalised) characters on row 4",
+                "message-data": {},
+            }
+        ]
+        self.assertCheckErrors(expected_errors, errors)
 
     def test_contains_lowercase_and_uppercase_characters(self):
         cells = [
             goodtables.cells.create_cell(
-                'department', 'Cooperative Governance And Traditional Affairs',
-                'department', row_number=1),
+                "department",
+                "Cooperative Governance And Traditional Affairs",
+                "department",
+                row_number=1,
+            ),
             goodtables.cells.create_cell(
-                'department', 'Social Development', 'department', row_number=2)
+                "department", "Social Development", "department", row_number=2
+            ),
         ]
-
-        errors = self.check.check_row(cells)
-
-        self.assertEqual(
-            len(errors), 0,
-            ('Department names that contain both lowercase and uppercase '
-             'characters should not create an error'))
+        errors = self.run_checks(self.check, [cells])
+        self.assertCheckErrors([], errors)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/checks/helpers.py
+++ b/tests/checks/helpers.py
@@ -1,0 +1,31 @@
+import unittest
+from typing import List, Sequence
+
+from goodtables import Error
+
+
+class BaseCheckTestCase(unittest.TestCase):
+    """
+    Base class for custom check tests.
+    """
+
+    # Remove the maxDiff limit, for larger diffs.
+    maxDiff = None
+
+    def run_checks(self, check, rows: Sequence[Sequence[dict]]) -> List[Error]:
+        """
+        Collect errors like `goodtables.inspector.Inspector`.
+        """
+        rows_errors = [
+            error for cells in rows for error in (check.check_row(cells) or [])
+        ]
+        table_errors = check.check_table() or []
+        return sorted([*rows_errors, *table_errors])
+
+    def assertCheckErrors(
+        self, expected_errors: List[dict], errors: List[Error]
+    ) -> None:
+        """
+        Assert the expected errors.
+        """
+        self.assertEqual(expected_errors, [dict(error) for error in errors])


### PR DESCRIPTION
This follows PR #11: I ended up hacking on this at the Codebridge community evening last night. 🙂️

This:

1. Tweaks the test assertions to check the full error content (to make sure we're actually reporting the right errors, and to have visibility of changes in output)
2. Pulls out some generic code for cell, row, and column constraint checking

(This also applies `isort` and `black` to the touched code, in the hope of standardising in that direction.)