### PR TITLE
Show message for goodtable exception

### DIFF
--- a/bin/run-checks.py
+++ b/bin/run-checks.py
@@ -14,7 +14,7 @@ def run_report(filepath):
     except Exception as e:
         print("===== Goodtables checks resulted in an error =====")
         traceback.print_exc(file=sys.stdout)
-        if isinstance(e, KeyError):
+        if isinstance(e, KeyError) and str(e) == "'field'":
             print(
                 "\n===== It looks like the dataset might contain unexpected columns. ====="
             )

--- a/bin/run-checks.py
+++ b/bin/run-checks.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import traceback
 
 from pprint import pformat
 
@@ -7,44 +8,67 @@ from data_checks.check_datapackage import run_checks
 
 
 def run_report(filepath):
-    print("===== Checking {} =====".format(filepath))
-    report = run_checks(filepath)
+    print("\n===== Checking {} =====".format(filepath))
+    try:
+        report = run_checks(filepath)
+    except Exception as e:
+        print("===== Goodtables checks resulted in an error =====")
+        traceback.print_exc(file=sys.stdout)
+        if isinstance(e, KeyError):
+            print(
+                "\n===== It looks like the dataset might contain unexpected columns. ====="
+            )
+        return 1
+    print("===== Validation Report =====")
     log_report(report)
-    return report['error-count'] + len(report['warnings'])
+    return report["error-count"] + len(report["warnings"])
+
 
 def log_report(report):
     # Borrowed from goodtables.cli
-    tables = report.pop('tables')
-    warnings = report['warnings']
-    print('DATASET')
-    print('='*7)
+    tables = report.pop("tables")
+    warnings = report["warnings"]
+    print("DATASET")
+    print("=" * 7)
     print(pformat(report))
     if warnings:
-        print('-'*9)
+        print("-" * 9)
     for warning in warnings:
-        print('Warning: %s' % warning)
+        print("Warning: %s" % warning)
     for table_number, table in enumerate(tables, start=1):
-        print('\nTABLE [%s]' % table_number)
-        print('='*9)
-        errors = table.pop('errors')
+        print("\nTABLE [%s]" % table_number)
+        print("=" * 9)
+        errors = table.pop("errors")
         print(pformat(table))
         if errors:
-            print('-'*9)
+            table_border = "-" * 67
+            error_format = "| {row:^3} | {column:^6} | {code:^38} | {message} |"
+            print("\nERRORS")
+            print("=" * 6)
+            print(table_border)
+            print(
+                error_format.format(
+                    row="Row", column="Column", code="Code", message="Message"
+                )
+            )
+            print(table_border)
         for error in errors:
-            template = '[{row-number},{column-number}] [{code}] {message}'
             substitutions = {
-                'row-number': error.get('row-number', '-'),
-                'column-number': error.get('column-number', '-'),
-                'code': error.get('code', '-'),
-                'message': error.get('message', '-'),
+                "row": error.get("row-number", "-"),
+                "column": error.get("column-number", "-"),
+                "code": error.get("code", "-"),
+                "message": error.get("message", "-"),
             }
-            message = template.format(**substitutions)
+            message = error_format.format(**substitutions)
             print(message)
+        if errors:
+            print(table_border)
+
 
 errors_or_warnings = 0
 dataset_count = 0
 
-datapackage_dir = sys.argv[1] if len(sys.argv) > 1 else  "./datapackages"
+datapackage_dir = sys.argv[1] if len(sys.argv) > 1 else "./datapackages"
 
 for dirpath, dirnames, filenames in os.walk(datapackage_dir):
     for filename in filenames:
@@ -53,7 +77,7 @@ for dirpath, dirnames, filenames in os.walk(datapackage_dir):
             errors_or_warnings += run_report(filepath)
             dataset_count += 1
 
-print("\nFound and checked {} datasets.".format(dataset_count))
+print("\nFound and checked {} dataset(s).".format(dataset_count))
 
 if errors_or_warnings:
     print("ERRORS OR WARNINGS EXIST: see above")


### PR DESCRIPTION
Try to make the error report a bit more understandable for non-technical users by adding more headers, formatting the errors in a table and giving a reason for the goodtables `KeyError: "field"`.